### PR TITLE
Fix Array to String conversion notices in clean()

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -114,6 +114,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				array(1, 3, 9),
 				'From generic cases'
 			),
+			'int_13' => array(
+				'int',
+				array(1, 'ab-123ab', '-ab123.456ab'),
+				array(1, 123, 123),
+				'From generic cases'
+			),
 			'uint_1' => array(
 				'uint',
 				-789,

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -127,7 +127,7 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				'From generic cases'
 			),
 			'uint_3' => array(
-				'int',
+				'uint',
 				array(-1, -3, -9),
 				array(1, 3, 9),
 				'From generic cases'

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -216,6 +216,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				array(1.0, -12, -12.456),
 				'From generic cases'
 			),
+			'float_12' => array(
+				'float',
+				array(1.0, 'abcdef-7E-10', '+27.3E-34', '+27.3e-34'),
+				array(1.0, -7E-10, 27.3E-34, 27.3e-34),
+				'From generic cases'
+			),
 			'bool_0' => array(
 				'bool',
 				$input,

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -117,7 +117,7 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 			'int_13' => array(
 				'int',
 				array(1, 'ab-123ab', '-ab123.456ab'),
-				array(1, 123, 123),
+				array(1, -123, 123),
 				'From generic cases'
 			),
 			'uint_1' => array(
@@ -136,6 +136,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				'uint',
 				array(-1, -3, -9),
 				array(1, 3, 9),
+				'From generic cases'
+			),
+			'uint_4' => array(
+				'int',
+				array(1, 'ab-123ab', '-ab123.456ab'),
+				array(1, 123, 123),
 				'From generic cases'
 			),
 			'float_01' => array(
@@ -202,6 +208,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				'float',
 				array(1.0, 3.1, 6.2),
 				array(1.0, 3.1, 6.2),
+				'From generic cases'
+			),
+			'float_11' => array(
+				'float',
+				array(1.0, 'abc-12. 456', 'abc-12.456abc'),
+				array(1.0, -12, -12.456),
 				'From generic cases'
 			),
 			'bool_0' => array(

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -108,6 +108,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				0,
 				'From generic cases'
 			),
+			'int_12' => array(
+				'int',
+				array(1, 3, 9),
+				array(1, 3, 9),
+				'From generic cases'
+			),
 			'uint_1' => array(
 				'uint',
 				-789,
@@ -118,6 +124,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				'uint',
 				'',
 				0,
+				'From generic cases'
+			),
+			'uint_3' => array(
+				'int',
+				array(-1, -3, -9),
+				array(1, 3, 9),
 				'From generic cases'
 			),
 			'float_01' => array(
@@ -178,6 +190,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				'float',
 				'',
 				0,
+				'From generic cases'
+			),
+			'float_10' => array(
+				'float',
+				array(1.0, 3.1, 6.2),
+				array(1.0, 3.1, 6.2),
 				'From generic cases'
 			),
 			'bool_0' => array(

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -206,17 +206,23 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 			),
 			'float_10' => array(
 				'float',
+				'27.3e-34',
+				27.3e-34,
+				'From generic cases'
+			),
+			'float_11' => array(
+				'float',
 				array(1.0, 3.1, 6.2),
 				array(1.0, 3.1, 6.2),
 				'From generic cases'
 			),
-			'float_11' => array(
+			'float_13' => array(
 				'float',
 				array(1.0, 'abc-12. 456', 'abc-12.456abc'),
 				array(1.0, -12, -12.456),
 				'From generic cases'
 			),
-			'float_12' => array(
+			'float_14' => array(
 				'float',
 				array(1.0, 'abcdef-7E-10', '+27.3E-34', '+27.3e-34'),
 				array(1.0, -7E-10, 27.3E-34, 27.3e-34),

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -139,7 +139,7 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 				'From generic cases'
 			),
 			'uint_4' => array(
-				'int',
+				'uint',
 				array(1, 'ab-123ab', '-ab123.456ab'),
 				array(1, 123, 123),
 				'From generic cases'

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -206,7 +206,15 @@ class InputFilter
 			case 'UINT':
 				if (is_array($source))
 				{
-					$matches = preg_grep('/-?[0-9]+/', $source);
+					$pattern = '/-?[0-9]+/';
+					//$matches = preg_grep('/-?[0-9]+/', $source);
+					$matches = array_filter(
+								$source, 
+								function($inlineFunction) use($pattern)
+								{
+									// This return is to the closure (i.e. inline-function)
+	    								return preg_grep($pattern, $inlineFunction);
+								});
 				}
 				else
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -173,7 +173,7 @@ class InputFilter
 		{
 			case 'INT':
 			case 'INTEGER':
-				$pattern = '/-?[0-9]+/';
+				$pattern = '/[-+]?\d+/';
 
 				if (is_array($source))
 				{
@@ -194,7 +194,7 @@ class InputFilter
 				break;
 
 			case 'UINT':
-				$pattern = '/-?[0-9]+/';
+				$pattern = '/[-+]?\d+/';
 
 				if (is_array($source))
 				{
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '/[-]?\d+(\.\d+)?([eE][-]?\d+)?/';
+				$pattern = '/[-+]?\d+(\.\d+)?([eE][-+]?\d+)?/';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -178,7 +178,12 @@ class InputFilter
 				if (is_array($source))
 				{
 					$matches = preg_grep($pattern, $source);
-					$result = $matches;
+
+					// Insure each value is an int
+					foreach ($matches as $each_number)
+					{
+					      $result[] = (int) $each_number;
+					}
 				}
 				else
 				{
@@ -194,7 +199,12 @@ class InputFilter
 				if (is_array($source))
 				{
 					$matches = preg_grep($pattern, $source);
-					$result = $matches;
+
+					// Insure each value is a uint
+					foreach ($matches as $each_number)
+					{
+					      $result[] = abs((int) $each_number);
+					}
 				}
 				else
 				{
@@ -211,7 +221,12 @@ class InputFilter
 				if (is_array($source))
 				{
 					$matches = preg_grep($pattern, $source);
-					$result = $matches;
+
+					// Insure each value is an float
+					foreach ($matches as $each_number)
+					{
+					      $result[] = (float) $each_number;
+					}
 				}
 				else
 				{
@@ -261,7 +276,12 @@ class InputFilter
 				if (is_array($source))
 				{
 					$matches = preg_grep($pattern, $source);
-					$result = $matches;
+
+					// Insure each value is a string
+					foreach ($matches as $each_value)
+					{
+					      $result[] = (string) $each_value;
+					}
 				}
 				else
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -183,7 +183,7 @@ class InputFilter
 					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
-				if (is_array($matches) && empty($matches[1]) && $matches[1] != 0)
+				if (is_array($matches) && empty($matches[1]))
 				{
 					$result = (int) $matches[0];
 				}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -235,7 +235,7 @@ class InputFilter
 				break;
 
 			case 'STRING':
-				$result = (string) $this->remove($this->decode((string) $source));
+					$result = (string) $this->remove(html_entity_decode($source, ENT_QUOTES, 'UTF-8'));
 				break;
 
 			case 'HTML':
@@ -286,7 +286,7 @@ class InputFilter
 						// Filter element for XSS and other 'bad' code etc.
 						if (is_string($value))
 						{
-							$result[$key] = $this->remove($this->decode((string) $source));
+							$result[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
 						}
 					}
 				}
@@ -296,7 +296,7 @@ class InputFilter
 					if (is_string($source) && !empty($source))
 					{
 						// Filter source for XSS and other 'bad' code etc.
-						$result = $this->remove($this->decode((string) $source));
+						$result = $this->remove(html_entity_decode($source, ENT_QUOTES, 'UTF-8'));
 					}
 					else
 					{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -182,7 +182,19 @@ class InputFilter
 					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
-				$result = isset($matches[0]) ? (int) $matches[0] : 0;
+				if (isset($matches[0]) && !is_array($matches))
+				{
+					$result = (int) $matches[0];
+				}
+				elseif(is_array($matches))
+				{
+					$result = $matches;
+				}
+				else
+				{
+					$result = 0;
+				}
+
 				break;
 
 			case 'UINT':

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -181,7 +181,7 @@ class InputFilter
 					foreach ($source as $eachString)
 					{
 						preg_match($pattern, (string) $eachString, $matches);
-						$result[] = isset($match[0]) ? (int) $match[0] : 0;;
+						$result[] = isset($matches[0]) ? (int) $matches[0] : 0;;
 					}
 				}
 				else

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -96,7 +96,7 @@ class InputFilter
 		'script',
 		'style',
 		'title',
-		'xml'
+		'xml',
 	);
 
 	/**
@@ -110,7 +110,7 @@ class InputFilter
 		'background',
 		'codebase',
 		'dynsrc',
-		'lowsrc'
+		'lowsrc',
 	);
 
 	/**

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -181,6 +181,7 @@ class InputFilter
 				{
 					preg_match('/-?[0-9]+/', $source, $matches);
 				}
+
 				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
@@ -193,6 +194,7 @@ class InputFilter
 				{
 					preg_match('/-?[0-9]+/', $source, $matches);
 				}
+
 				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				break;
 
@@ -206,12 +208,29 @@ class InputFilter
 				{
 					preg_match('/-?[0-9]+(\.[0-9]+)?/', $source, $matches);
 				}
+
 				$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				break;
 
 			case 'BOOL':
 			case 'BOOLEAN':
-				$result = (bool) $source;
+				if (is_string($source))
+				{
+					$result = (bool) $source;
+				}
+				else
+				{
+					$result = array();
+
+					foreach ($source as $key => $value)
+					{
+						if (is_string($value))
+						{
+							$result[$key] = (bool) $value;
+						}
+					}
+				}
+
 				break;
 
 			case 'WORD':
@@ -232,7 +251,24 @@ class InputFilter
 				break;
 
 			case 'STRING':
-				$result = (string) $this->remove($this->decode((string) $source));
+				if (is_string($source))
+				{
+					$result = (string) $this->remove(html_entity_decode($source, ENT_QUOTES, 'UTF-8'));
+				}
+				else
+				{
+					$result = array();
+
+					foreach ($source as $key => $value)
+					{
+						// Filter element for XSS and other 'bad' code etc.
+						if (is_string($value))
+						{
+							$result[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
+						}
+					}
+				}
+
 				break;
 
 			case 'HTML':
@@ -254,6 +290,7 @@ class InputFilter
 				{
 					preg_match($pattern, $source, $matches);
 				}
+
 				$result = isset($matches[0]) ? (string) $matches[0] : '';
 				break;
 
@@ -275,16 +312,16 @@ class InputFilter
 				// Are we dealing with an array?
 				if (is_array($source))
 				{
+					$result = array();
+
 					foreach ($source as $key => $value)
 					{
 						// Filter element for XSS and other 'bad' code etc.
 						if (is_string($value))
 						{
-							$source[$key] = $this->remove($this->decode($value));
+							$result[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
 						}
 					}
-
-					$result = $source;
 				}
 				else
 				{
@@ -292,7 +329,7 @@ class InputFilter
 					if (is_string($source) && !empty($source))
 					{
 						// Filter source for XSS and other 'bad' code etc.
-						$result = $this->remove($this->decode($source));
+						$result = $this->remove(html_entity_decode($source, ENT_QUOTES, 'UTF-8'));
 					}
 					else
 					{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)';
+				$pattern = "[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?";
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -178,7 +178,7 @@ class InputFilter
 				{
 					$pattern = '/-?[0-9]+/';
 					$matches = array_filter(
-								$source, 
+								$source,
 								function($inlineFunction) use($pattern)
 								{
 									// This return is to the closure (i.e. inline-function)
@@ -199,7 +199,7 @@ class InputFilter
 				{
 					$pattern = '/-?[0-9]+/';
 					$matches = array_filter(
-								$source, 
+								$source,
 								function($inlineFunction) use($pattern)
 								{
 									// This return is to the closure (i.e. inline-function)
@@ -219,7 +219,15 @@ class InputFilter
 			case 'DOUBLE':
 				if (is_array($source))
 				{
-					$matches = preg_grep('/-?[0-9]+(\.[0-9]+)?/', $source);
+					$pattern = '/-?[0-9]+(\.[0-9]+)?/';
+					$matches = array_filter(
+								$source,
+								function($inlineFunction) use($pattern)
+								{
+									// This return is to the closure (i.e. inline-function)
+									return preg_grep($pattern, $inlineFunction);
+								}
+								);
 				}
 				else
 				{
@@ -268,7 +276,14 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = preg_grep($pattern, $source);
+					$matches = array_filter(
+						$source,
+						function($inlineFunction) use($pattern)
+						{
+							// This return is to the closure (i.e. inline-function)
+							return preg_grep($pattern, $inlineFunction);
+						}
+						);
 				}
 				else
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '/-?[0-9]+(\.[0-9]+)?/';
+				$pattern = '[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = "[\-\+]*\d+*(\.\d+)([eE][\-\+]*\d+)";
+				$pattern = "[\-\+]?*\d+(\.\d+)?([eE][\-\+]\d+)?";
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -183,7 +183,7 @@ class InputFilter
 					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
-				if (is_array($matches) && empty($matches[1]))
+				if (is_array($matches) && empty($matches[1]) && isset($matches[0]))
 				{
 					$result = (int) $matches[0];
 				}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -182,7 +182,7 @@ class InputFilter
 								function($inlineFunction) use($pattern)
 								{
 									// This return is to the closure (i.e. inline-function)
-									preg_match($pattern, (string) $source, $match);
+									preg_match($pattern, (string) $inlineFunction, $match);
 									return $match;
 								}
 					);

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -181,7 +181,8 @@ class InputFilter
 					foreach ($source as $eachString)
 					{
 						preg_match($pattern, (string) $eachString, $matches);
-						$result[] = isset($matches[0]) ? (int) $matches[0] : 0;;
+
+						$result[] = isset($matches[0]) ? (int) $matches[0] : 0;
 					}
 				}
 				else
@@ -197,12 +198,12 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = preg_grep($pattern, $source);
-
-					// Insure each value is a uint
-					foreach ($matches as $each_number)
+					// Itterate through the array
+					foreach ($source as $eachString)
 					{
-						$result[] = abs((int) $each_number);
+						preg_match($pattern, (string) $eachString, $matches);
+
+						$result[] = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 					}
 				}
 				else
@@ -219,12 +220,12 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = preg_grep($pattern, $source);
-
-					// Insure each value is an float
-					foreach ($matches as $each_number)
+					// Itterate through the array
+					foreach ($source as $eachString)
 					{
-						$result[] = (float) $each_number;
+						preg_match($pattern, (string) $eachString, $matches);
+
+						$result[] = isset($matches[0]) ? (float) $matches[0] : 0;
 					}
 				}
 				else
@@ -237,7 +238,7 @@ class InputFilter
 
 			case 'BOOL':
 			case 'BOOLEAN':
-					$result = (bool) $source;
+				$result = (bool) $source;
 				break;
 
 			case 'WORD':
@@ -258,7 +259,7 @@ class InputFilter
 				break;
 
 			case 'STRING':
-					$result = (string) $this->remove(html_entity_decode((string) $source, ENT_QUOTES, 'UTF-8'));
+				$result = (string) $this->remove(html_entity_decode((string) $source, ENT_QUOTES, 'UTF-8'));
 				break;
 
 			case 'HTML':
@@ -274,12 +275,12 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = preg_grep($pattern, $source);
-
-					// Insure each value is a string
-					foreach ($matches as $each_value)
+					// Itterate through the array
+					foreach ($source as $eachString)
 					{
-						$result[] = (string) $each_value;
+						preg_match($pattern, (string) $eachString, $matches);
+
+						$result[] = isset($matches[0]) ? (string) $matches[0] : '';
 					}
 				}
 				else

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -177,14 +177,7 @@ class InputFilter
 				if (is_array($source))
 				{
 					$pattern = '/-?[0-9]+/';
-					$matches = array_filter(
-								$source,
-								function($inlineFunction) use($pattern)
-								{
-									// This return is to the closure (i.e. inline-function)
-									return preg_grep($pattern, $inlineFunction);
-								}
-								);
+					$matches = preg_grep($pattern, $source);
 				}
 				else
 				{
@@ -198,14 +191,7 @@ class InputFilter
 				if (is_array($source))
 				{
 					$pattern = '/-?[0-9]+/';
-					$matches = array_filter(
-								$source,
-								function($inlineFunction) use($pattern)
-								{
-									// This return is to the closure (i.e. inline-function)
-									return preg_grep($pattern, $inlineFunction);
-								}
-								);
+					$matches = preg_grep($pattern, $source);
 				}
 				else
 				{
@@ -220,14 +206,7 @@ class InputFilter
 				if (is_array($source))
 				{
 					$pattern = '/-?[0-9]+(\.[0-9]+)?/';
-					$matches = array_filter(
-								$source,
-								function($inlineFunction) use($pattern)
-								{
-									// This return is to the closure (i.e. inline-function)
-									return preg_grep($pattern, $inlineFunction);
-								}
-								);
+					$matches = preg_grep($pattern, $source);
 				}
 				else
 				{
@@ -276,14 +255,7 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = array_filter(
-						$source,
-						function($inlineFunction) use($pattern)
-						{
-							// This return is to the closure (i.e. inline-function)
-							return preg_grep($pattern, $inlineFunction);
-						}
-						);
+					$matches = preg_grep($pattern, $source);
 				}
 				else
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -174,20 +174,20 @@ class InputFilter
 			case 'INT':
 			case 'INTEGER':
 				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source[0], $matches);
+				preg_grep('/-?[0-9]+/', $source, $matches);
 				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
 			case 'UINT':
 				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source[0], $matches);
+				preg_grep('/-?[0-9]+/', $source, $matches);
 				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
 				// Only use the first floating point value
-				preg_match('/-?[0-9]+(\.[0-9]+)?/', (string) $source[0], $matches);
+				preg_grep('/-?[0-9]+(\.[0-9]+)?/', $source, $matches);
 				$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				break;
 
@@ -227,7 +227,7 @@ class InputFilter
 
 			case 'PATH':
 				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
-				preg_match($pattern, (string) $source[0], $matches);
+				preg_grep($pattern, $source, $matches);
 				$result = isset($matches[0]) ? (string) $matches[0] : '';
 				break;
 

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = "[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?";
+				$pattern = "[\-\+]*\d+*(\.\d+)([eE][\-\+]*\d+)";
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -173,6 +173,7 @@ class InputFilter
 		{
 			case 'INT':
 			case 'INTEGER':
+
 				if (is_array($source))
 				{
 					$matches = preg_grep('/-?[0-9]+/', $source);
@@ -188,6 +189,11 @@ class InputFilter
 				}
 				elseif(is_array($matches))
 				{
+					foreach ($matches as $key => $value)
+					{
+						$matches[$key] = (int) $value;
+					}
+
 					$result = $matches;
 				}
 				else

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -174,20 +174,20 @@ class InputFilter
 			case 'INT':
 			case 'INTEGER':
 				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source, $matches);
+				preg_match('/-?[0-9]+/', (string) $source[0], $matches);
 				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
 			case 'UINT':
 				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source, $matches);
+				preg_match('/-?[0-9]+/', (string) $source[0], $matches);
 				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
 				// Only use the first floating point value
-				preg_match('/-?[0-9]+(\.[0-9]+)?/', (string) $source, $matches);
+				preg_match('/-?[0-9]+(\.[0-9]+)?/', (string) $source[0], $matches);
 				$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				break;
 
@@ -227,7 +227,7 @@ class InputFilter
 
 			case 'PATH':
 				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
-				preg_match($pattern, (string) $source, $matches);
+				preg_match($pattern, (string) $source[0], $matches);
 				$result = isset($matches[0]) ? (string) $matches[0] : '';
 				break;
 

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '/[-+]?\d+(\.\d+)?([eE][-+]\d+)?/';
+				$pattern = '/[-]?\d+(\.\d+)?([eE][-]?\d+)?/';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -183,7 +183,7 @@ class InputFilter
 					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
-				if (is_array($matches) && empty($matches[1]) && isset($matches[0]))
+				if (is_array($matches) && isset($matches[0]) && !isset($matches[1]))
 				{
 					$result = (int) $matches[0];
 				}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -183,15 +183,12 @@ class InputFilter
 								{
 									// This return is to the closure (i.e. inline-function)
 									preg_match($pattern, (string) $inlineFunction, $match);
-									return $match;
+
+									return isset($match[0]) ? (int) $match[0] : 0;
 								}
 					);
 
-					// Insure each value is an int
-					foreach ($matches as $each_number)
-					{
-						$result[] = (int) $each_number;
-					}
+					$result[] = $matches;
 				}
 				else
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?';
+				$pattern = '[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -235,24 +235,7 @@ class InputFilter
 				break;
 
 			case 'STRING':
-				if (is_string($source))
-				{
-					$result = (string) $this->remove(html_entity_decode($source, ENT_QUOTES, 'UTF-8'));
-				}
-				else
-				{
-					$result = array();
-
-					foreach ($source as $key => $value)
-					{
-						// Filter element for XSS and other 'bad' code etc.
-						if (is_string($value))
-						{
-							$result[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
-						}
-					}
-				}
-
+				$result = (string) $this->remove($this->decode((string) $source));
 				break;
 
 			case 'HTML':
@@ -303,7 +286,7 @@ class InputFilter
 						// Filter element for XSS and other 'bad' code etc.
 						if (is_string($value))
 						{
-							$result[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
+							$result[$key] = $this->remove($this->decode((string) $source));
 						}
 					}
 				}
@@ -313,7 +296,7 @@ class InputFilter
 					if (is_string($source) && !empty($source))
 					{
 						// Filter source for XSS and other 'bad' code etc.
-						$result = $this->remove(html_entity_decode($source, ENT_QUOTES, 'UTF-8'));
+						$result = $this->remove($this->decode((string) $source));
 					}
 					else
 					{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -182,7 +182,7 @@ class InputFilter
 					// Insure each value is an int
 					foreach ($matches as $each_number)
 					{
-					      $result[] = (int) $each_number;
+						$result[] = (int) $each_number;
 					}
 				}
 				else
@@ -203,7 +203,7 @@ class InputFilter
 					// Insure each value is a uint
 					foreach ($matches as $each_number)
 					{
-					      $result[] = abs((int) $each_number);
+						$result[] = abs((int) $each_number);
 					}
 				}
 				else
@@ -225,7 +225,7 @@ class InputFilter
 					// Insure each value is an float
 					foreach ($matches as $each_number)
 					{
-					      $result[] = (float) $each_number;
+						$result[] = (float) $each_number;
 					}
 				}
 				else
@@ -280,7 +280,7 @@ class InputFilter
 					// Insure each value is a string
 					foreach ($matches as $each_value)
 					{
-					      $result[] = (string) $each_value;
+						$result[] = (string) $each_value;
 					}
 				}
 				else

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -183,7 +183,7 @@ class InputFilter
 					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
-				if (is_array($matches) && is_null($matches[1]))
+				if (is_array($matches) && empty($matches[1]) && $matches[1] != 0)
 				{
 					$result = (int) $matches[0];
 				}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -183,7 +183,7 @@ class InputFilter
 					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
-				if (isset($matches[0]) && !is_array($matches))
+				if (is_array($matches) && is_null($matches[1]))
 				{
 					$result = (int) $matches[0];
 				}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '[-+]?\d+(\.\d+)?([eE][-+]\d+)?';
+				$pattern = '/[-+]?\d+(\.\d+)?([eE][-+]\d+)?/';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -173,47 +173,52 @@ class InputFilter
 		{
 			case 'INT':
 			case 'INTEGER':
+				$pattern = '/-?[0-9]+/';
 
 				if (is_array($source))
 				{
-					$pattern = '/-?[0-9]+/';
 					$matches = preg_grep($pattern, $source);
+					$result = $matches;
 				}
 				else
 				{
-					preg_match('/-?[0-9]+/', (string) $source, $matches);
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				}
 
-				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
 			case 'UINT':
+				$pattern = '/-?[0-9]+/';
+
 				if (is_array($source))
 				{
-					$pattern = '/-?[0-9]+/';
 					$matches = preg_grep($pattern, $source);
+					$result = $matches;
 				}
 				else
 				{
-					preg_match('/-?[0-9]+/', (string) $source, $matches);
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				}
 
-				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
+				$pattern = '/-?[0-9]+(\.[0-9]+)?/';
+
 				if (is_array($source))
 				{
-					$pattern = '/-?[0-9]+(\.[0-9]+)?/';
 					$matches = preg_grep($pattern, $source);
+					$result = $matches;
 				}
 				else
 				{
-					preg_match('/-?[0-9]+(\.[0-9]+)?/', (string) $source, $matches);
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				}
 
-				$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				break;
 
 			case 'BOOL':
@@ -256,13 +261,14 @@ class InputFilter
 				if (is_array($source))
 				{
 					$matches = preg_grep($pattern, $source);
+					$result = $matches;
 				}
 				else
 				{
 					preg_match($pattern, $source, $matches);
+					$result = isset($matches[0]) ? (string) $matches[0] : '';
 				}
 
-				$result = isset($matches[0]) ? (string) $matches[0] : '';
 				break;
 
 			case 'TRIM':
@@ -280,6 +286,7 @@ class InputFilter
 				break;
 
 			default:
+
 				// Are we dealing with an array?
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -176,45 +176,36 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = preg_grep('/-?[0-9]+/', $source);
+					$pattern = '/-?[0-9]+/';
+					$matches = array_filter(
+								$source, 
+								function($inlineFunction) use($pattern)
+								{
+									// This return is to the closure (i.e. inline-function)
+									return preg_grep($pattern, $inlineFunction);
+								}
+								);
 				}
 				else
 				{
 					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
-				if (is_array($matches) && isset($matches[0]) && !isset($matches[1]))
-				{
-					$result = (int) $matches[0];
-				}
-				elseif(is_array($matches))
-				{
-					foreach ($matches as $key => $value)
-					{
-						$matches[$key] = (int) $value;
-					}
-
-					$result = $matches;
-				}
-				else
-				{
-					$result = 0;
-				}
-
+				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
 			case 'UINT':
 				if (is_array($source))
 				{
 					$pattern = '/-?[0-9]+/';
-					//$matches = preg_grep('/-?[0-9]+/', $source);
 					$matches = array_filter(
 								$source, 
 								function($inlineFunction) use($pattern)
 								{
 									// This return is to the closure (i.e. inline-function)
-	    								return preg_grep($pattern, $inlineFunction);
-								});
+									return preg_grep($pattern, $inlineFunction);
+								}
+								);
 				}
 				else
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -177,18 +177,12 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = array_filter(
-								$source,
-								function($inlineFunction) use($pattern)
-								{
-									// This return is to the closure (i.e. inline-function)
-									preg_match($pattern, (string) $inlineFunction, $match);
-
-									return isset($match[0]) ? (int) $match[0] : 0;
-								}
-					);
-
-					$result[] = $matches;
+					// Itterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($match[0]) ? (int) $match[0] : 0;;
+					}
 				}
 				else
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -311,16 +311,16 @@ class InputFilter
 				// Are we dealing with an array?
 				if (is_array($source))
 				{
-					$result = array();
-
 					foreach ($source as $key => $value)
 					{
 						// Filter element for XSS and other 'bad' code etc.
 						if (is_string($value))
 						{
-							$result[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
+							$source[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
 						}
 					}
+	
+					$result = $source;
 				}
 				else
 				{
@@ -332,7 +332,7 @@ class InputFilter
 					}
 					else
 					{
-						// Not an array or string.. return the passed parameter
+						// Not an array or string... return the passed parameter
 						$result = $source;
 					}
 				}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -177,7 +177,15 @@ class InputFilter
 
 				if (is_array($source))
 				{
-					$matches = preg_grep($pattern, $source);
+					$matches = array_filter(
+								$source,
+								function($inlineFunction) use($pattern)
+								{
+									// This return is to the closure (i.e. inline-function)
+									preg_match($pattern, (string) $source, $match);
+									return $match;
+								}
+					);
 
 					// Insure each value is an int
 					foreach ($matches as $each_number)

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = "[\-\+]?*\d+(\.\d+)?([eE][\-\+]\d+)?";
+				$pattern = '[-+]?\d+(\.\d+)?([eE][-+]\d+)?';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -168,26 +168,36 @@ class InputFilter
 	 */
 	public function clean($source, $type = 'string')
 	{
+		// Are we dealing with an array? We need a string for some $type switch cases.
+		if (is_array($source))
+		{
+			$stringSource = (string) array_shift($source);
+		}
+		else
+		{
+			$stringSource = $source;
+		}
+		
 		// Handle the type constraint
 		switch (strtoupper($type))
 		{
 			case 'INT':
 			case 'INTEGER':
 				// Only use the first integer value
-				$matches = preg_grep('/-?[0-9]+/', $source);
+				preg_match('/-?[0-9]+/', $stringSource, $matches);
 				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
 			case 'UINT':
 				// Only use the first integer value
-				$matches = preg_grep('/-?[0-9]+/', $source);
+				preg_match('/-?[0-9]+/', $stringSource, $matches);
 				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
 				// Only use the first floating point value
-				$matches = preg_grep('/-?[0-9]+(\.[0-9]+)?/', $source);
+				preg_match('/-?[0-9]+(\.[0-9]+)?/', $stringSource, $matches);
 				$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				break;
 
@@ -227,7 +237,7 @@ class InputFilter
 
 			case 'PATH':
 				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
-				$matches = preg_grep($pattern, $source);
+				preg_match($pattern, $stringSource, $matches);
 				$result = isset($matches[0]) ? (string) $matches[0] : '';
 				break;
 
@@ -296,8 +306,8 @@ class InputFilter
 		$attrSubSet[1] = strtolower($attrSubSet[1]);
 
 		return (((strpos($attrSubSet[1], 'expression') !== false) && ($attrSubSet[0]) == 'style') || (strpos($attrSubSet[1], 'javascript:') !== false) ||
-			(strpos($attrSubSet[1], 'behaviour:') !== false) || (strpos($attrSubSet[1], 'vbscript:') !== false) ||
-			(strpos($attrSubSet[1], 'mocha:') !== false) || (strpos($attrSubSet[1], 'livescript:') !== false));
+				(strpos($attrSubSet[1], 'behaviour:') !== false) || (strpos($attrSubSet[1], 'vbscript:') !== false) ||
+				(strpos($attrSubSet[1], 'mocha:') !== false) || (strpos($attrSubSet[1], 'livescript:') !== false));
 	}
 
 	/**
@@ -483,7 +493,7 @@ class InputFilter
 					}
 				}
 				else
-				// No more equal signs so add any extra text in the tag into the attribute array [eg. checked]
+					// No more equal signs so add any extra text in the tag into the attribute array [eg. checked]
 				{
 					if ($fromSpace != '/')
 					{
@@ -534,7 +544,7 @@ class InputFilter
 					}
 				}
 				else
-				// Closing tag
+					// Closing tag
 				{
 					$preTag .= '</' . $tagName . '>';
 				}
@@ -589,7 +599,7 @@ class InputFilter
 			// AND blacklisted attributes
 			if ((!preg_match('/[a-z]*$/i', $attrSubSet[0]))
 				|| (($this->xssAuto) && ((in_array(strtolower($attrSubSet[0]), $this->attrBlacklist))
-				|| (substr($attrSubSet[0], 0, 2) == 'on'))))
+										 || (substr($attrSubSet[0], 0, 2) == 'on'))))
 			{
 				continue;
 			}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -168,36 +168,44 @@ class InputFilter
 	 */
 	public function clean($source, $type = 'string')
 	{
-		// Are we dealing with an array? We need a string for some $type switch cases.
-		if (is_array($source))
-		{
-			$stringSource = (string) array_shift($source);
-		}
-		else
-		{
-			$stringSource = $source;
-		}
-		
-		// Handle the type constraint
+		// Handle the type constraint cases and when $source is an array
 		switch (strtoupper($type))
 		{
 			case 'INT':
 			case 'INTEGER':
-				// Only use the first integer value
-				preg_match('/-?[0-9]+/', $stringSource, $matches);
+				if (is_array($source))
+				{
+					$matches = preg_grep('/-?[0-9]+/', $source);
+				}
+				else
+				{
+					preg_match('/-?[0-9]+/', $source, $matches);
+				}
 				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
 			case 'UINT':
-				// Only use the first integer value
-				preg_match('/-?[0-9]+/', $stringSource, $matches);
+				if (is_array($source))
+				{
+					$matches = preg_grep('/-?[0-9]+/', $source);
+				}
+				else
+				{
+					preg_match('/-?[0-9]+/', $source, $matches);
+				}
 				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				// Only use the first floating point value
-				preg_match('/-?[0-9]+(\.[0-9]+)?/', $stringSource, $matches);
+				if (is_array($source))
+				{
+					$matches = preg_grep('/-?[0-9]+(\.[0-9]+)?/', $source);
+				}
+				else
+				{
+					preg_match('/-?[0-9]+(\.[0-9]+)?/', $source, $matches);
+				}
 				$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				break;
 
@@ -237,7 +245,15 @@ class InputFilter
 
 			case 'PATH':
 				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
-				preg_match($pattern, $stringSource, $matches);
+
+				if (is_array($source))
+				{
+					$matches = preg_grep($pattern, $source);
+				}
+				else
+				{
+					preg_match($pattern, $source, $matches);
+				}
 				$result = isset($matches[0]) ? (string) $matches[0] : '';
 				break;
 

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -179,7 +179,7 @@ class InputFilter
 				}
 				else
 				{
-					preg_match('/-?[0-9]+/', $source, $matches);
+					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
 				$result = isset($matches[0]) ? (int) $matches[0] : 0;
@@ -192,7 +192,7 @@ class InputFilter
 				}
 				else
 				{
-					preg_match('/-?[0-9]+/', $source, $matches);
+					preg_match('/-?[0-9]+/', (string) $source, $matches);
 				}
 
 				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
@@ -206,7 +206,7 @@ class InputFilter
 				}
 				else
 				{
-					preg_match('/-?[0-9]+(\.[0-9]+)?/', $source, $matches);
+					preg_match('/-?[0-9]+(\.[0-9]+)?/', (string) $source, $matches);
 				}
 
 				$result = isset($matches[0]) ? (float) $matches[0] : 0;
@@ -214,23 +214,7 @@ class InputFilter
 
 			case 'BOOL':
 			case 'BOOLEAN':
-				if (is_string($source))
-				{
 					$result = (bool) $source;
-				}
-				else
-				{
-					$result = array();
-
-					foreach ($source as $key => $value)
-					{
-						if (is_string($value))
-						{
-							$result[$key] = (bool) $value;
-						}
-					}
-				}
-
 				break;
 
 			case 'WORD':
@@ -652,7 +636,7 @@ class InputFilter
 			// AND blacklisted attributes
 			if ((!preg_match('/[a-z]*$/i', $attrSubSet[0]))
 				|| (($this->xssAuto) && ((in_array(strtolower($attrSubSet[0]), $this->attrBlacklist))
-										 || (substr($attrSubSet[0], 0, 2) == 'on'))))
+				|| (substr($attrSubSet[0], 0, 2) == 'on'))))
 			{
 				continue;
 			}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -173,7 +173,7 @@ class InputFilter
 		{
 			case 'INT':
 			case 'INTEGER':
-				$pattern = '/[-+]?\d+/';
+				$pattern = '/[-+]?[0-9]+/';
 
 				if (is_array($source))
 				{
@@ -194,7 +194,7 @@ class InputFilter
 				break;
 
 			case 'UINT':
-				$pattern = '/[-+]?\d+/';
+				$pattern = '/[-+]?[0-9]+/';
 
 				if (is_array($source))
 				{
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '/[-+]?\d+(\.\d+)?([eE][-+]?\d+)?/';
+				$pattern = '/[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?/';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -216,7 +216,7 @@ class InputFilter
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$';
+				$pattern = '[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)';
 
 				if (is_array($source))
 				{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -319,7 +319,7 @@ class InputFilter
 							$source[$key] = $this->remove(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
 						}
 					}
-	
+
 					$result = $source;
 				}
 				else

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -235,7 +235,7 @@ class InputFilter
 				break;
 
 			case 'STRING':
-					$result = (string) $this->remove(html_entity_decode($source, ENT_QUOTES, 'UTF-8'));
+					$result = (string) $this->remove(html_entity_decode((string) $source, ENT_QUOTES, 'UTF-8'));
 				break;
 
 			case 'HTML':

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -174,20 +174,20 @@ class InputFilter
 			case 'INT':
 			case 'INTEGER':
 				// Only use the first integer value
-				preg_grep('/-?[0-9]+/', $source, $matches);
+				$matches = preg_grep('/-?[0-9]+/', $source);
 				$result = isset($matches[0]) ? (int) $matches[0] : 0;
 				break;
 
 			case 'UINT':
 				// Only use the first integer value
-				preg_grep('/-?[0-9]+/', $source, $matches);
+				$matches = preg_grep('/-?[0-9]+/', $source);
 				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
 				// Only use the first floating point value
-				preg_grep('/-?[0-9]+(\.[0-9]+)?/', $source, $matches);
+				$matches = preg_grep('/-?[0-9]+(\.[0-9]+)?/', $source);
 				$result = isset($matches[0]) ? (float) $matches[0] : 0;
 				break;
 
@@ -227,7 +227,7 @@ class InputFilter
 
 			case 'PATH':
 				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
-				preg_grep($pattern, $source, $matches);
+				$matches = preg_grep($pattern, $source);
 				$result = isset($matches[0]) ? (string) $matches[0] : '';
 				break;
 


### PR DESCRIPTION
* Adds basic first level processing of array's of numbers
  * Fixes Array to String conversion notices in clean() for number cases
* Replaces `decode()` with `html_entity_decode()`
* Updates pcre patterns for numbers
  * Fixes floats case to properly handle exponent type floats rather than just decimal floats
* Adds new general cases to test and verify the array of numbers functionality
* Code style: fixes missing comma at end of array lists.