### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/OutputFilterTest.php
+++ b/Tests/OutputFilterTest.php
@@ -68,9 +68,9 @@ class OutputFilterTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	public function testObjectHTMLSafe()
+	public function testObjectHtmlSafe()
 	{
-		$this->object->objectHTMLSafe($this->safeObject, null, 'string3');
+		$this->object->objectHtmlSafe($this->safeObject, null, 'string3');
 		$this->assertEquals('&lt;script&gt;alert();&lt;/script&gt;', $this->safeObject->string1, "Script tag should be defused");
 		$this->assertEquals('This is a test.', $this->safeObject->string2, "Plain text should pass");
 		$this->assertEquals('<script>alert(3);</script>', $this->safeObject->string3, "This Script tag should be passed");
@@ -81,9 +81,9 @@ class OutputFilterTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	public function testObjectHTMLSafeWithArray()
+	public function testObjectHtmlSafeWithArray()
 	{
-		$this->object->objectHTMLSafe($this->safeObject, null, array('string1', 'string3'));
+		$this->object->objectHtmlSafe($this->safeObject, null, array('string1', 'string3'));
 		$this->assertEquals('<script>alert();</script>', $this->safeObject->string1, "Script tag should pass array test");
 		$this->assertEquals('This is a test.', $this->safeObject->string2, "Plain text should pass array test");
 		$this->assertEquals('<script>alert(3);</script>', $this->safeObject->string3, "This Script tag should pass array test");
@@ -94,11 +94,11 @@ class OutputFilterTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	public function testLinkXHTMLSafe()
+	public function testLinkXhtmlSafe()
 	{
 		$this->assertEquals(
 			'<a href="http://www.example.com/index.frd?one=1&amp;two=2&amp;three=3">This & That</a>',
-			$this->object->linkXHTMLSafe('<a href="http://www.example.com/index.frd?one=1&two=2&three=3">This & That</a>'),
+			$this->object->linkXhtmlSafe('<a href="http://www.example.com/index.frd?one=1&two=2&three=3">This & That</a>'),
 			'Should clean ampersands only out of link, not out of link text'
 		);
 	}
@@ -108,11 +108,11 @@ class OutputFilterTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	public function testStringURLSafe()
+	public function testStringUrlSafe()
 	{
 		$this->assertEquals(
 			'1234567890-qwertyuiop-qwertyuiop-asdfghjkl-asdfghjkl-zxcvbnm-zxcvbnm',
-			$this->object->stringURLSafe('`1234567890-=~!@#$%^&*()_+	qwertyuiop[]\QWERTYUIOP{}|asdfghjkl;\'ASDFGHJKL:"zxcvbnm,./ZXCVBNM<>?'),
+			$this->object->stringUrlSafe('`1234567890-=~!@#$%^&*()_+	qwertyuiop[]\QWERTYUIOP{}|asdfghjkl;\'ASDFGHJKL:"zxcvbnm,./ZXCVBNM<>?'),
 			'Should clean keyboard string down to ASCII-7'
 		);
 	}
@@ -124,11 +124,11 @@ class OutputFilterTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testStringURLUnicodeSlug()
+	public function testStringUrlUnicodeSlug()
 	{
 		$this->assertEquals(
 			'what-if-i-do-not-get_this-right',
-			$this->object->stringURLUnicodeSlug('What-if I do.not get_this right?'),
+			$this->object->stringUrlUnicodeSlug('What-if I do.not get_this right?'),
 			'Should be URL unicoded'
 		);
 	}

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -32,7 +32,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function objectHTMLSafe(&$mixed, $quote_style = ENT_QUOTES, $exclude_keys = '')
+	public static function objectHtmlSafe(&$mixed, $quote_style = ENT_QUOTES, $exclude_keys = '')
 	{
 		if (is_object($mixed))
 		{
@@ -66,7 +66,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function linkXHTMLSafe($input)
+	public static function linkXhtmlSafe($input)
 	{
 		$regex = 'href="([^"]*(&(amp;){0})[^"]*)*?"';
 
@@ -92,7 +92,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function stringURLSafe($string)
+	public static function stringUrlSafe($string)
 	{
 		// Remove any '-' from the string since they will be used as concatenaters
 		$str = str_replace('-', ' ', $string);
@@ -121,7 +121,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function stringURLUnicodeSlug($string)
+	public static function stringUrlUnicodeSlug($string)
 	{
 		// Replace double byte whitespaces by single byte (East Asian languages)
 		$str = preg_replace('/\xE3\x80\x80/', ' ', $string);


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.