### PR TITLE
Custom test to demonstrate everything breaks

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -1377,7 +1377,7 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
-	public function georgesCustomTest()
+	public function testCustomExtensionOddity()
 	{
 		$filter = new InputFilter;
 		$this->assertEquals(

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -1376,4 +1376,14 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 			$message
 		);
 	}
+
+	public function georgesCustomTest()
+	{
+		$filter = new InputFilter;
+		$this->assertEquals(
+			$filter->clean('1<4', 'string'),
+			'1<4',
+			'This sucks hard'
+		);
+	}
 }

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -1377,7 +1377,12 @@ class InputFilterTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
-	public function testCustomExtensionOddity()
+	/**
+	 * Test that a less than symbol isn't removed.
+	 *
+	 * @return  void
+	 */
+	public function testLessThanSymbolsAreNotStripped()
 	{
 		$filter = new InputFilter;
 		$this->assertEquals(


### PR DESCRIPTION
So if you run a string containing a symbol `<` through the filter class then you find that it gets stripped.

It's something inside the tag cleaning - but obviously we don't want all `<` tags to be stripped
