### PR TITLE
use negative lookbehind/lookahed instead of a lot of str_replaces

### DIFF
--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -154,18 +154,10 @@ class OutputFilter
 	 * @return  string  Processed string.
 	 *
 	 * @since   1.0
-	 * @todo    There must be a better way???
 	 */
 	public static function ampReplace($text)
 	{
-		$text = str_replace('&&', '*--*', $text);
-		$text = str_replace('&#', '*-*', $text);
-		$text = str_replace('&amp;', '&', $text);
-		$text = preg_replace('|&(?![\w]+;)|', '&amp;', $text);
-		$text = str_replace('*-*', '&#', $text);
-		$text = str_replace('*--*', '&&', $text);
-
-		return $text;
+		return preg_replace('/(?<!&)&(?!&|#|[\w]+;)/', '&amp;', $text);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Use regular expressions negative lookbehind/lookahed instead of a lot of str_replaces.

Explanation: https://regex101.com/r/OTEpzZ/1

### Testing Instructions

Add this to any joomla index.php template

```php
$originalText = '&amp; & && &# &amp;test= &test= &&test= &#test=';
$app->enqueueMessage('Original Text: ' . htmlspecialchars($originalText), 'warning');

$timeStart = microtime(true);
$app->enqueueMessage(sprintf('Option 1: %s', htmlspecialchars(JFilterOutput::ampReplace($originalText))), 'warning');
$app->enqueueMessage(sprintf('Option 1: [%f]', (microtime(true) - $timeStart)), 'warning');

$timeStart = microtime(true);
$app->enqueueMessage(sprintf('Option 2: %s', htmlspecialchars(preg_replace('/(?<!&)&(?!&|#|[\w]+;)/', '&amp;', $originalText))), 'warning');
$app->enqueueMessage(sprintf('Option 2: [%f]', (microtime(true) - $timeStart)), 'warning');
```

Result
![image](https://cloud.githubusercontent.com/assets/9630530/21360672/cde17242-c6d8-11e6-8bed-2d1bae1ef492.png)

Test other possible amp replaces.
Results must be always the same as previous.

### Documentation Changes Required

None.

If ok please port to 2.0