### PR TITLE
generic utf-8 multibyte cases which cause the filter to fail.

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -699,11 +699,23 @@ class InputFilterTest extends TestCase
 				'Fred',
 				'From specific cases'
 			),
+			'Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strong>محمد</strong></em>',
+				'محمد',
+				'From specific utf-8 multibyte cases'
+			),
 			'Malformed Nested tags' => array(
 				'',
 				'<em><strongFred</strong></em>',
 				'strongFred',
 				'From specific cases'
+			),
+			'Malformed Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strongمحمد</strong></em>',
+				'strongمحمد',
+				'From specific utf-8 multibyte cases'
 			),
 			'Unquoted Attribute Without Space' => array(
 				'',
@@ -816,11 +828,23 @@ class InputFilterTest extends TestCase
 				'Fred',
 				'From specific cases'
 			),
+			'Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strong>محمد</strong></em>',
+				'محمد',
+				'From specific utf-8 multibyte cases'
+			),
 			'Malformed Nested tags' => array(
 				'',
 				'<em><strongFred</strong></em>',
 				'strongFred',
 				'From specific cases'
+			),
+			'Malformed Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strongمحمد</strong></em>',
+				'strongمحمد',
+				'From specific utf-8 multibyte cases'
 			),
 			'Unquoted Attribute Without Space' => array(
 				'',
@@ -952,11 +976,23 @@ class InputFilterTest extends TestCase
 				'Fred',
 				'From specific cases'
 			),
+			'Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strong>محمد</strong></em>',
+				'محمد',
+				'From specific utf-8 multibyte cases'
+			),
 			'Malformed Nested tags' => array(
 				'',
 				'<em><strongFred</strong></em>',
 				'strongFred',
 				'From specific cases'
+			),
+			'Malformed Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strongمحمد</strong></em>',
+				'strongمحمد',
+				'From specific utf-8 multibyte cases'
 			),
 			'Unquoted Attribute Without Space' => array(
 				'',
@@ -1058,11 +1094,23 @@ class InputFilterTest extends TestCase
 				'Fred',
 				'From specific cases'
 			),
+			'Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strong>محمد</strong></em>',
+				'محمد',
+				'From specific utf-8 multibyte cases'
+			),
 			'Malformed Nested tags' => array(
 				'',
 				'<em><strongFred</strong></em>',
 				'strongFred',
 				'From specific cases'
+			),
+			'Malformed Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strongمحمد</strong></em>',
+				'strongمحمد',
+				'From specific utf-8 multibyte cases'
 			),
 			'Unquoted Attribute Without Space' => array(
 				'',

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -432,6 +432,12 @@ class InputFilterTest extends TestCase
 				array('fred', '$user69'),
 				'From generic cases'
 			),
+			'user_04' => array(
+				'username',
+				'محمد',
+				'محمد',
+				'From generic utf-8 multibyte cases'
+			),
 			'trim_01' => array(
 				'trim',
 				'nonbreaking nonbreaking',
@@ -546,11 +552,23 @@ class InputFilterTest extends TestCase
 				'<em><strong>Fred</strong></em>',
 				'From generic cases'
 			),
+			'Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strong>محمد</strong></em>',
+				'<em><strong>محمد</strong></em>',
+				'From generic utf-8 multibyte cases'
+			),
 			'Malformed Nested tags' => array(
 				'',
 				'<em><strongFred</strong></em>',
 				'<em>strongFred</strong></em>',
 				'From generic cases'
+			),
+			'Malformed Nested tags with utf-8 multibyte persian characters' => array(
+				'',
+				'<em><strongمحمد</strong></em>',
+				'<em>strongمحمد</strong></em>',
+				'From generic utf-8 multibyte cases'
 			),
 			'Unquoted Attribute Without Space' => array(
 				'',


### PR DESCRIPTION
Pull Request for Issue create some generic utf-8 multibyte test cases to show problems

### Summary of Changes
creates some generic utf-8 multibyte test cases

### Testing Instructions
Tests should pass, but notice that the simple use of Persian characters breaks the tests even though they copy the "Fred" generic cases.

