### PR TITLE
Update to allow for - character in attribute name

### DIFF
--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -864,7 +864,7 @@ class InputFilter
 			}
 
 			// Remove all symbols
-			$attrSubSet[0] = preg_replace('/[^\p{L}\p{N}\s]/u', '', $attrSubSet[0]);
+			$attrSubSet[0] = preg_replace('/[^\p{L}\p{N}\-\s]/u', '', $attrSubSet[0]);
 
 			// Remove all "non-regular" attribute names
 			// AND blacklisted attributes


### PR DESCRIPTION
Line 867 introduced in Joomla 3.8.8 attempts to clean up attribute names in an HTML tag by removing all symbols. This change removes the - character, which is valid in attribute names and required for data attributes, eg: data-value="1"

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/20579

### Summary of Changes

This PR excludes the dash character form the symbols removed from attribute names by the input filter.

### Testing Instructions
While logged in as a Super User:

In the Global Configuration, set the Default Editor to Editor - None.

In the Text Filters tab, set the Filter Type value to Default BlackList for the Super User group.

Save.

Go to Content -> Articles -> Add New Article.

Give the new article a Title, and add the following HTML, or a variation of it, to the Content field:
```html
<p data-value="1">Some text</p>
```

Click the Save button.

### Expected result
The article should be save with the original content added intact.

```html
<p data-value="1">Some text</p>
```

### Actual result
The hyphen is removed from the data attribute, resulting in
```html
<p datavalue="1">Some text</p>
```

### Documentation Changes Required
None.