### PR TITLE
Add test case for attribute name with dash

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -654,6 +654,12 @@ class InputFilterTest extends TestCase
 				'img height="123 /&gt;"',
 				'From generic cases'
 			),
+			'Attribute with dash' => array(
+				'string',
+				'<img data-value="1" />',
+				'<img data-value="1" />',
+				'From generic cases'
+			),
 		);
 	}
 


### PR DESCRIPTION
### Summary of Changes

Add a unit test for attribute names that contain a dash character, eg:

```html
<img data-value="1" />
```
