### PR TITLE
Remove whitelist/blacklist terminology from the filter class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor/
 composer.phar
 composer.lock
 phpunit.xml
+
+.idea/


### PR DESCRIPTION
### Summary of Changes
Renames the properties from blacklist and names them blocked attributes/tags which is more accurate anyhow. Deprecates all the old statics for version 2.

### Testing Instructions
None

### Documentation Changes Required
Nope. Version 2 upgrade docs when this gets merged up will need amending
