### PR TITLE
[1.x] Don't include development related files in distribution package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
+.github/ export-ignore
+Tests/ export-ignore
+.drone.jsonnet export-ignore
+.drone.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.gitmodules export-ignore
-.travis/ export-ignore
-.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/README.md
+++ b/README.md
@@ -23,4 +23,10 @@ Alternatively, you can simply run the following from the command line:
 composer require joomla/filter "~1.0"
 ```
 
+If you want to include the test sources, use
+
+```sh
+composer require --prefer-source joomla/filter "~1.0"
+```
+
 Note that the `Joomla\Language` package is an optional dependency and is only required if the application requires the use of `OutputFilter::stringURLSafe`.


### PR DESCRIPTION
### Summary of Changes

* `.gitattributes` is updated to reflect changes
* development related files and directories excluded from distribution packages

### Testing Instructions

* Code review
* The files and directories listed in `.gitattributes` are not included in the zip package

### Documentation Changes Required

`README.md` is changed accordingly.
