### PR TITLE
Change the windows path filter regex and add some testcases

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -432,6 +432,18 @@ class InputFilterTest extends TestCase
 				'C:\Documents\Newsletters\Summer2018.pdf',
 				'From generic cases'
 			),
+			'windows path lowercase drive letter' => array(
+				'path',
+				'c:\Documents\Newsletters\Summer2018.pdf',
+				'c:\Documents\Newsletters\Summer2018.pdf',
+				'From generic cases'
+			),
+			'windows path folder' => array(
+				'path',
+				'C:\Documents\Newsletters',
+				'C:\Documents\Newsletters',
+				'From generic cases'
+			),
 			'windows path with double separator' => array(
 				'path',
 				'C:\Documents\Newsletters\\Summer2018.pdf',

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1006,7 +1006,7 @@ class InputFilter
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Z])?[A-Za-z0-9_\/:\\\\-]+[A-Za-z0-9_\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1006,7 +1006,7 @@ class InputFilter
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Z])?[A-Za-z0-9_\/:\\\\-]+[A-Za-z0-9_\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{


### PR DESCRIPTION
### Summary of Changes

Change the windows path filter regex and add some testcases.
The following is validated here: https://regexr.com/)

With the existing regex:
`^([A-Z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$`
You can not have a valid path as `C:\Documents\Newsletters`

With the modified regex:
`/^([A-Z])?[A-Za-z0-9_\/:\\\\-]+[A-Za-z0-9_\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/`

This is possible.

This PR also adds a dedicated test for lovercased drive letters.

### Testing Instructions

make sure the tests still passes

### Documentation Changes Required

none