### PR TITLE
Add an windows test with slash

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -476,7 +476,7 @@ class InputFilterTest extends TestCase
 			),
 			'windows path with /'                                           => array(
 				'path',
-				'C:\Documents\\Newsletters/tmp',
+				'C:\\Documents\\Newsletters/tmp',
 				'C:\Documents\Newsletters/tmp',
 				'From generic cases'
 			),

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -474,6 +474,12 @@ class InputFilterTest extends TestCase
 				'C:\Documents\Newsletters\Summer2018.pdf',
 				'From generic cases'
 			),
+			'windows path with /'                                           => array(
+				'path',
+				'C:\Documents\\Newsletters/tmp',
+				'C:\Documents\Newsletters/tmp',
+				'From generic cases'
+			),
 			'user_01'                                                       => array(
 				'username',
 				'&<f>r%e\'d',


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/32076 cc @richard67  @nibra 

### Summary of Changes

Add an windows test with slash

### Todo

- [ ] extende the regex to allow the slash at the right place
or
- [ ] require the path to be passed via path::clean

### Testing Instructions

Try to test the PR #32076 the test fails as there is a slash in the regex

### Documentation Changes Required

none.