### PR TITLE
CleanPath: Allow slashes in path pattern for Windows to be able to handle partly normalized paths

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -480,6 +480,12 @@ class InputFilterTest extends TestCase
 				'C:\Documents\Newsletters/tmp',
 				'From generic cases'
 			),
+			'windows path with 2 times /'                                   => array(
+				'path',
+				'C:\\Documents/Newsletters/tmp',
+				'C:\Documents\Newsletters/tmp',
+				'From generic cases'
+			),
 			'user_01'                                                       => array(
 				'username',
 				'&<f>r%e\'d',

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -483,7 +483,7 @@ class InputFilterTest extends TestCase
 			'windows path with 2 times /'                                   => array(
 				'path',
 				'C:\\Documents/Newsletters/tmp',
-				'C:\Documents\Newsletters/tmp',
+				'C:\Documents/Newsletters/tmp',
 				'From generic cases'
 			),
 			'user_01'                                                       => array(

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -477,13 +477,13 @@ class InputFilterTest extends TestCase
 			'windows path with /'                                           => array(
 				'path',
 				'C:\\Documents\\Newsletters/tmp',
-				'C:\Documents\Newsletters/tmp',
+				'C:\Documents\Newsletters\tmp',
 				'From generic cases'
 			),
 			'windows path with 2 times /'                                   => array(
 				'path',
 				'C:\\Documents/Newsletters/tmp',
-				'C:\Documents/Newsletters/tmp',
+				'C:\Documents\Newsletters\tmp',
 				'From generic cases'
 			),
 			'user_01'                                                       => array(

--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -474,6 +474,18 @@ class InputFilterTest extends TestCase
 				'C:\Documents\Newsletters\Summer2018.pdf',
 				'From generic cases'
 			),
+			'windows path with 2 times double separator'                    => array(
+				'path',
+				'C:\Documents\\Newsletters\\Summer2018.pdf',
+				'C:\Documents\Newsletters\Summer2018.pdf',
+				'From generic cases'
+			),
+			'windows path with 3 times double separator'                    => array(
+				'path',
+				'C:\\Documents\\Newsletters\\Summer2018.pdf',
+				'C:\Documents\Newsletters\Summer2018.pdf',
+				'From generic cases'
+			),
 			'windows path with /'                                           => array(
 				'path',
 				'C:\\Documents\\Newsletters/tmp',
@@ -483,6 +495,12 @@ class InputFilterTest extends TestCase
 			'windows path with 2 times /'                                   => array(
 				'path',
 				'C:\\Documents/Newsletters/tmp',
+				'C:\Documents\Newsletters\tmp',
+				'From generic cases'
+			),
+			'windows path with 3 times /'                                   => array(
+				'path',
+				'C:/Documents/Newsletters/tmp',
 				'C:\Documents\Newsletters\tmp',
 				'From generic cases'
 			),

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1004,7 +1004,7 @@ class InputFilter
 	 */
 	private function cleanPath($source)
 	{
-		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/]+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*((\\\\\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($linuxPattern, $source))
 		{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1011,7 +1011,7 @@ class InputFilter
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\/\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1004,14 +1004,14 @@ class InputFilter
 	 */
 	private function cleanPath($source)
 	{
-		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/]+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($linuxPattern, $source))
 		{
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Za-z]:(\\|\\\\|\/))?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\|\\\\|\/)[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:(\\\\|\/))?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1011,7 +1011,7 @@ class InputFilter
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\/\.-]*(\\\\+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\/\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1011,7 +1011,7 @@ class InputFilter
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:(\\{1,2}|\/))?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\{1,2}|\/)[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1011,11 +1011,11 @@ class InputFilter
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_\/-]+[A-Za-z0-9_\/\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:\\\\)?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{
-			return preg_replace('~\\\\+~', '\\', $source);
+			return preg_replace('~(\\\\|\/)+~', '\\', $source);
 		}
 
 		return '';

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -1004,14 +1004,14 @@ class InputFilter
 	 */
 	private function cleanPath($source)
 	{
-		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*((\\\\\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($linuxPattern, $source))
 		{
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Za-z]:(\\{1,2}|\/))?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\{1,2}|\/)[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:(\\|\\\\|\/))?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\|\\\\|\/)[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

Fix the regex for Windows so it can handle partly normalized paths like e.g. `C:\\xampp\\htdocs\\joomla-cms/tmp`, which is the `$tmp_path` in configuration.php after a new installation of a current staging branch of the CMS on an XAMPP on Windows.

Partly normalized paths like e.g. `C:\\xampp\\htdocs\\joomla-cms/tmp` are absolutely ok in environments like PHP or like I have it in my job with Java, where paths on any OS are later normalized using "/" as separator (what out Path::clean does).

So we have to stick here to the rules of PHP how it handles Windows paths, and not to the rules of Windows, where a slash in a file or folder name is not allowed.

@zero-24 @nibra If having partly normalized paths like described above is not desired, we can replace the slashes `/` by backslashes `\` at the end of the routine here https://github.com/joomla-framework/filter/blob/872338c69e1539959d05059d533a483edcc76978/src/InputFilter.php#L1018
by changing it to
`return preg_replace('~(\\\\|/)+~', '\\', $source);`
Then we would not have `'C:\Documents\Newsletters/tmp'` or `'C:\Documents/Newsletters/tmp'` but `'C:\Documents\Newsletters\tmp'` as result of the 2 new unit tests.

I think we don't need that, i.e. the PR is good as it is, because when appending the update package's file name to the path, the Joomla Update component will anyway use a slash `/`.

What do you think?

### Testing Instructions

Test https://github.com/joomla/joomla-cms/pull/32076 with XAMPP on Windows.

### Documentation Changes Required

None.