### PR TITLE
Only perform filter if $type is not empty

### DIFF
--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -281,7 +281,7 @@ class InputFilter
 
 		$method = 'clean' . $type;
 
-		if (method_exists($this, $method))
+		if ($type !== '' && method_exists($this, $method))
 		{
 			return $this->$method((string) $source);
 		}


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
This PR fixes the issue on Joomla CMS PR https://github.com/joomla/joomla-cms/pull/32207. Basically, we should only call the type specific filter method if $type is actually passed (not an empty string).

I don't know what is testing instructions. Maybe code review should be enough?