### PR TITLE
Handle objects in input filter clean function

### DIFF
--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -284,14 +284,12 @@ class InputFilter
 
 		if (\is_object($source))
 		{
-			$result = new stdClass;
-
 			foreach ($source as $key => $value)
 			{
-				$result->$key = $this->clean($value, $type);
+				$source->$key = $this->clean($value, $type);
 			}
 
-			return $result;
+			return $source;
 		}
 
 		$method = 'clean' . $type;

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -9,6 +9,7 @@
 namespace Joomla\Filter;
 
 use Joomla\String\StringHelper;
+use stdClass;
 
 /**
  * InputFilter is a class for filtering input from any data source
@@ -283,7 +284,14 @@ class InputFilter
 
 		if (\is_object($source))
 		{
-			return (object) $this->clean((array) $source, $type);
+			$result = new stdClass;
+
+			foreach ($source as $key => $value)
+			{
+				$result->$key = $this->clean($value, $type);
+			}
+
+			return $result;
 		}
 
 		$method = 'clean' . $type;

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -229,25 +229,27 @@ class InputFilter
 	/**
 	 * Cleans the given input source based on the instance configuration and specified data type
 	 *
-	 * @param   string|string[]  $source  Input string/array-of-string to be 'cleaned'
-	 * @param   string           $type    The return type for the variable:
-	 *                                    INT:       An integer
-	 *                                    UINT:      An unsigned integer
-	 *                                    FLOAT:     A floating point number
-	 *                                    BOOLEAN:   A boolean value
-	 *                                    WORD:      A string containing A-Z or underscores only (not case sensitive)
-	 *                                    ALNUM:     A string containing A-Z or 0-9 only (not case sensitive)
-	 *                                    CMD:       A string containing A-Z, 0-9, underscores, periods or hyphens (not case sensitive)
-	 *                                    BASE64:    A string containing A-Z, 0-9, forward slashes, plus or equals (not case sensitive)
-	 *                                    STRING:    A fully decoded and sanitised string (default)
-	 *                                    HTML:      A sanitised string
-	 *                                    ARRAY:     An array
-	 *                                    PATH:      A sanitised file path
-	 *                                    TRIM:      A string trimmed from normal, non-breaking and multibyte spaces
-	 *                                    USERNAME:  Do not use (use an application specific filter)
-	 *                                    RAW:       The raw string is returned with no filtering
-	 *                                    unknown:   An unknown filter will act like STRING. If the input is an array it will return an
-	 *                                               array of fully decoded and sanitised strings.
+	 * @param   string|string[]|object|object[]  $source  Input string/array-of-string to be 'cleaned'
+	 * @param   string                           $type    The return type for the variable:
+	 *                                                    INT:       An integer
+	 *                                                    UINT:      An unsigned integer
+	 *                                                    FLOAT:     A floating point number
+	 *                                                    BOOLEAN:   A boolean value
+	 *                                                    WORD:      A string containing A-Z or underscores only (not case sensitive)
+	 *                                                    ALNUM:     A string containing A-Z or 0-9 only (not case sensitive)
+	 *                                                    CMD:       A string containing A-Z, 0-9, underscores, periods or hyphens (not
+	 *                                                               case sensitive)
+	 *                                                    BASE64:    A string containing A-Z, 0-9, forward slashes, plus or equals (not
+	 *                                                               case sensitive)
+	 *                                                    STRING:    A fully decoded and sanitised string (default)
+	 *                                                    HTML:      A sanitised string
+	 *                                                    ARRAY:     An array
+	 *                                                    PATH:      A sanitised file path
+	 *                                                    TRIM:      A string trimmed from normal, non-breaking and multibyte spaces
+	 *                                                    USERNAME:  Do not use (use an application specific filter)
+	 *                                                    RAW:       The raw string is returned with no filtering
+	 *                                                    unknown:   An unknown filter will act like STRING. If the input is an array
+	 *                                                               it will return an array of fully decoded and sanitised strings.
 	 *
 	 * @return  mixed  'Cleaned' version of the `$source` parameter
 	 *

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -283,7 +283,7 @@ class InputFilter
 
 		if (\is_object($source))
 		{
-			foreach ($source as $key => $value)
+			foreach (get_object_vars($source) as $key => $value)
 			{
 				$source->$key = $this->clean($value, $type);
 			}

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -230,27 +230,27 @@ class InputFilter
 	/**
 	 * Cleans the given input source based on the instance configuration and specified data type
 	 *
-	 * @param   string|string[]|object|object[]  $source  Input string/array-of-string/object/array-of-object to be 'cleaned'
-	 * @param   string                           $type    The return type for the variable:
-	 *                                                    INT:       An integer
-	 *                                                    UINT:      An unsigned integer
-	 *                                                    FLOAT:     A floating point number
-	 *                                                    BOOLEAN:   A boolean value
-	 *                                                    WORD:      A string containing A-Z or underscores only (not case sensitive)
-	 *                                                    ALNUM:     A string containing A-Z or 0-9 only (not case sensitive)
-	 *                                                    CMD:       A string containing A-Z, 0-9, underscores, periods or hyphens (not
-	 *                                                               case sensitive)
-	 *                                                    BASE64:    A string containing A-Z, 0-9, forward slashes, plus or equals (not
-	 *                                                               case sensitive)
-	 *                                                    STRING:    A fully decoded and sanitised string (default)
-	 *                                                    HTML:      A sanitised string
-	 *                                                    ARRAY:     An array
-	 *                                                    PATH:      A sanitised file path
-	 *                                                    TRIM:      A string trimmed from normal, non-breaking and multibyte spaces
-	 *                                                    USERNAME:  Do not use (use an application specific filter)
-	 *                                                    RAW:       The raw string is returned with no filtering
-	 *                                                    unknown:   An unknown filter will act like STRING. If the input is an array
-	 *                                                               it will return an array of fully decoded and sanitised strings.
+	 * @param   string|string[]|object  $source  Input string/array-of-string/object to be 'cleaned'
+	 * @param   string                  $type    The return type for the variable:
+	 *                                           INT:       An integer
+	 *                                           UINT:      An unsigned integer
+	 *                                           FLOAT:     A floating point number
+	 *                                           BOOLEAN:   A boolean value
+	 *                                           WORD:      A string containing A-Z or underscores only (not case sensitive)
+	 *                                           ALNUM:     A string containing A-Z or 0-9 only (not case sensitive)
+	 *                                           CMD:       A string containing A-Z, 0-9, underscores, periods or hyphens (not case
+	 *                                                      sensitive)
+	 *                                           BASE64:    A string containing A-Z, 0-9, forward slashes, plus or equals (not case
+	 *                                                      sensitive)
+	 *                                           STRING:    A fully decoded and sanitised string (default)
+	 *                                           HTML:      A sanitised string
+	 *                                           ARRAY:     An array
+	 *                                           PATH:      A sanitised file path
+	 *                                           TRIM:      A string trimmed from normal, non-breaking and multibyte spaces
+	 *                                           USERNAME:  Do not use (use an application specific filter)
+	 *                                           RAW:       The raw string is returned with no filtering
+	 *                                           unknown:   An unknown filter will act like STRING. If the input is an array it will
+	 *                                                      return an array of fully decoded and sanitised strings.
 	 *
 	 * @return  mixed  'Cleaned' version of the `$source` parameter
 	 *

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -229,7 +229,7 @@ class InputFilter
 	/**
 	 * Cleans the given input source based on the instance configuration and specified data type
 	 *
-	 * @param   string|string[]|object|object[]  $source  Input string/array-of-string to be 'cleaned'
+	 * @param   string|string[]|object|object[]  $source  Input string/array-of-string/object/array-of-object to be 'cleaned'
 	 * @param   string                           $type    The return type for the variable:
 	 *                                                    INT:       An integer
 	 *                                                    UINT:      An unsigned integer

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -9,7 +9,6 @@
 namespace Joomla\Filter;
 
 use Joomla\String\StringHelper;
-use stdClass;
 
 /**
  * InputFilter is a class for filtering input from any data source

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -279,6 +279,11 @@ class InputFilter
 			return $result;
 		}
 
+		if (\is_object($source))
+		{
+			return (object) $this->clean((array) $source, $type);
+		}
+
 		$method = 'clean' . $type;
 
 		if (method_exists($this, $method))


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/32207#issuecomment-770230746 .

### Summary of Changes

Let the input filter also clean objects.

Due to the recursion, the clean function will also work for nested objects.

### Testing Instructions

Test https://github.com/joomla/joomla-cms/pull/32207 and see that it fails.

Then still on the same testing environment, apply the same change as made in this PR here for the 1.x version of the input filter to the local 2.0.0-beta4 version of the input filter, and then test again, and check that it works now and that changed filters are properly saved in database.

### Documentation Changes Required

None.