### PR TITLE
Use unknow filter for kill script test with object

### DIFF
--- a/Tests/InputFilterTest.php
+++ b/Tests/InputFilterTest.php
@@ -1917,6 +1917,6 @@ class InputFilterTest extends TestCase
 
 		$filter = new InputFilter();
 
-		$this->assertEquals($expected, $filter->clean($object));
+		$this->assertEquals($expected, $filter->clean($object, ''));
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

Fix the new test for object.

The same test for non-objects uses the unknown filter type `''`.

It should be the same when testing the object.

### Testing Instructions

CI tests pass.

### Documentation Changes Required

None.