### PR TITLE
Declare compatibility with PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/joomla-framework/filter",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^5.3.10|~7.0",
+        "php": "^5.3.10|~7.0|^8.0",
         "joomla/string": "~1.3|~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Pull Request for Issue #N/A

### Summary of Changes

Currently, `joomla/filter` cannot be installed on PHP 8.0 due to the following error:

```
Problem 2
    - joomla/filter is locked to version 1.3.5 and an update of this package was not requested.
    - joomla/filter 1.3.5 requires php ^5.3.10|~7.0 -> your php version (8.0.3) does not satisfy that requirement.
```

However, your automated test suite [already seems to be testing it against PHP 8.0](https://ci.joomla.org/joomla-framework/filter/60/12/3) and it works just fine! This PR explicitly describes support for PHP 8.0.

### Testing Instructions

N/A

### Documentation Changes Required
