### PR TITLE
Fixes wrong replacements when having multibyte characters in tag attr…

### DIFF
--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -774,7 +774,7 @@ class InputFilter
 				// We have a closing quote, convert its byte position to a UTF-8 string length, using non-multibyte substr()
 				$stringBeforeQuote = substr($attributeValueRemainder, 0, $matches[0][1]);
 				$closeQuoteChars   = StringHelper::strlen($stringBeforeQuote);
-				$nextAfter         = $nextBefore + $matches[0][1];
+				$nextAfter         = $nextBefore + $closeQuoteChars;
 			}
 			else
 			{


### PR DESCRIPTION
…ibute values

I had a closer look to the problem with the "infinite loop" (which means that at the end you are running into the maximum execution time error) mentioned in joomla/joomla-cms#34967.

The problem is, that `escapeAttributeValues()` does not handle multibyte characters correctly. It makes wrong replacements in the tag attribute values which leads  to the "infinite loop" in the further processing after the function has been applied.

One can reproduce the wrong replacement by doing the following changes to a fresch installation of Joomla 4.0.0

1. Change the access of the function `protected function escapeAttributeValues($source)` in **_/libraries/vendor/joomla/filter/src/InputFilter.php_** from **protected** to **public**.
2. Add the following code to line 179 of **_administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php_**
```
		$inputFilter = \Joomla\CMS\Filter\InputFilter::getInstance(array(), array(), 1, 1);
		$testhtml = '<input alt="PayPal – The safer, easier way to pay online!" name="submit" src="https://www.paypalobjects.com/de_DE/CH/i/btn/btn_donateCC_LG.gif" type="image" />';

		echo "<p>Before applying escapeAttributeValues():<br/>";
		echo(htmlentities($testhtml));
		echo "</p>";
		echo "<p>After applying escapeAttributeValues():<br/>";
		echo(htmlentities($inputFilter->escapeAttributeValues($testhtml)));
		echo "</p>";
```
3. Open the Joomla 4 dashboard in the backend. Notice the hyphen in the "alt" attribute of the input tag, which is a multibyte character (3 bytes). See the wrong replacements `...  online!&quot; "ame=`.

 The problem is, that `$matches[0][1]` counts in bytes and `$attributeValue = StringHelper::substr($remainder, $nextBefore, $nextAfter - $nextBefore);` counts in multibyte characters.

After applying the patch there is no wrong replacement any more.
