### PR TITLE
 PHP 8.1 deprecation Passing null to parameter string

### DIFF
--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -153,6 +153,11 @@ class OutputFilter
 	 */
 	public static function stringUrlUnicodeSlug($string)
 	{
+		if ($string === null)
+		{
+			$string = '';
+		}
+
 		// Replace double byte whitespaces by single byte (East Asian languages)
 		$str = preg_replace('/\xE3\x80\x80/', ' ', $string);
 


### PR DESCRIPTION
( ! ) Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in \libraries\vendor\joomla\filter\src\OutputFilter.php on line 157

Pull Request for Issue #

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
