### PR TITLE
Adapting OutputFilter::stringUrlSafe() to CMS class

### DIFF
--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -122,6 +122,9 @@ class OutputFilter
         // Trim white spaces at beginning and end of alias and make lowercase
         $str = trim(StringHelper::strtolower($str));
 
+        // Remove any apostrophe. We do it here to ensure it is not replaced by a '-'
+        $str = str_replace("'", '', $str);
+
         // Remove any duplicate whitespace, and ensure all characters are alphanumeric
         $str = preg_replace('/(\s|[^A-Za-z0-9\-])+/', '-', $str);
 


### PR DESCRIPTION
### Summary of Changes
I'm trying to make the OutputFilter class from this package as compatible to the current CMS class as possible. This PR tries to achieve that with stringUrlSafe(). For this this one line was added. In addition, we have to add the language package as dependency to the CMS.

### Testing Instructions

### Documentation Changes Required
