### PR TITLE
Fixing notice in test code, fixing value for $quoteStyle

### DIFF
--- a/Tests/OutputFilterTest.php
+++ b/Tests/OutputFilterTest.php
@@ -22,6 +22,8 @@ class FilterTestObject
 
 	public $string3;
 
+	public $array1;
+
 	/**
 	 * Sets up a dummy object for the output filter to be tested against
 	 */

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -40,7 +40,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function objectHtmlSafe(&$mixed, $quoteStyle = \ENT_QUOTES | \ENT_SUBSTITUTE | \ENT_HTML401, $excludeKeys = '')
+	public static function objectHtmlSafe(&$mixed, $quoteStyle = \ENT_QUOTES, $excludeKeys = '')
 	{
 		if (\is_null($quoteStyle))
 		{

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -44,7 +44,7 @@ class OutputFilter
 	{
 		if (\is_null($quoteStyle))
 		{
-			$quoteStyle = \ENT_QUOTES | \ENT_SUBSTITUTE | \ENT_HTML401;
+			$quoteStyle = \ENT_QUOTES;
 		}
 
 		if (\is_object($mixed))

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -40,8 +40,13 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function objectHtmlSafe(&$mixed, $quoteStyle = \ENT_QUOTES, $excludeKeys = '')
+	public static function objectHtmlSafe(&$mixed, $quoteStyle = \ENT_QUOTES | \ENT_SUBSTITUTE | \ENT_HTML401, $excludeKeys = '')
 	{
+		if (\is_null($quoteStyle))
+		{
+			$quoteStyle = \ENT_QUOTES | \ENT_SUBSTITUTE | \ENT_HTML401;
+		}
+
 		if (\is_object($mixed))
 		{
 			foreach (get_object_vars($mixed) as $k => $v)


### PR DESCRIPTION
### Summary of Changes
Right now, the tests throw notices due to an undefined object attribute. This is fixed in the test class.

The second change fixes additional notices. You can't hand over a null value for `$flags` to `htmlspecialchars()`. This change makes sure that it is the PHP default for `htmlspecialchars()` when no value is given. Also, the default value of the methods parameter has been set to the default value of the PHP function.

Reference: https://www.php.net/manual/en/function.htmlspecialchars

### Testing Instructions

### Documentation Changes Required
