### PR TITLE
Adding OutputFilter::stringJSSafe()

### DIFF
--- a/Tests/OutputFilterTest.php
+++ b/Tests/OutputFilterTest.php
@@ -102,6 +102,18 @@ class OutputFilterTest extends TestCase
 	}
 
 	/**
+	 * Tests making strings safe for usage in JS
+	 */
+	public function testStringJSSafe()
+	{
+		$this->assertEquals(
+			'\u0054\u0065\u0073\u0074\u0020\u0073\u0074\u0072\u0069\u006e\u0067\u0020\u0045\u0073\u0070\u0061\u00f1\u006f\u006c\u0020\u0420\u0443\u0441\u0441\u043a\u0438\u0439\u0020\ud55c\uad6d\uc5b4\u0020\u{1f910}',
+			$this->object->stringJSSafe('Test string Español Русский 한국어 🤐'),
+			'Should convert the string to unicode escaped string'
+		);
+	}
+
+	/**
 	 * Tests filtering strings down to ASCII-7 lowercase URL text
 	 */
 	public function testStringUrlSafeWithoutALanguageInstance()

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -90,6 +90,37 @@ class OutputFilter
 	}
 
 	/**
+	 * Processes a string and escapes it for use in JavaScript
+	 *
+	 * @param   string  $string  String to process
+	 *
+	 * @return  string  Processed text
+	 *
+	 * @since   3.0
+	 */
+	public static function stringJSSafe($string)
+	{
+		$chars   = preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
+		$newStr = '';
+
+		foreach ($chars as $chr)
+		{
+			$code = str_pad(dechex(StringHelper::ord($chr)), 4, '0', STR_PAD_LEFT);
+
+			if (strlen($code) < 5)
+			{
+				$newStr .= '\\u' . $code;
+			}
+			else
+			{
+				$newStr .= '\\u{' . $code . '}';
+			}
+		}
+
+		return $newStr;
+	}
+
+	/**
 	 * Generates a URL safe version of the specified string with language transliteration.
 	 *
 	 * This method processes a string and replaces all accented UTF-8 characters by unaccented


### PR DESCRIPTION
### Summary of Changes
This is part of the process of deprecating the CMS Filter package in favor of the framework package. This adds the stringJSSafe() method to the OutputFilter class.

This recreates the PR #56 in order to already use it in Joomla 4.4 and thus make it available to third party developers both in 4.4 and 5.0.

### Testing Instructions
Tests should pass. Codereview.

### Documentation Changes Required
