### PR TITLE
Adapting OutputFilter::stringUrlSafe() to CMS class

### DIFF
--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -133,6 +133,9 @@ class OutputFilter
 		// Trim white spaces at beginning and end of alias and make lowercase
 		$str = trim(StringHelper::strtolower($str));
 
+		// Remove any apostrophe. We do it here to ensure it is not replaced by a '-'
+		$str = str_replace("'", '', $str);
+
 		// Remove any duplicate whitespace, and ensure all characters are alphanumeric
 		$str = preg_replace('/(\s|[^A-Za-z0-9\-])+/', '-', $str);
 


### PR DESCRIPTION
### Summary of Changes
I'm trying to make the OutputFilter class from this package as compatible to the current CMS class as possible. This PR tries to achieve that with stringUrlSafe(). For this this one line was added. In addition, we have to add the language package as dependency to the CMS.

This recreates the PR https://github.com/joomla-framework/filter/pull/57 in order to already use it in Joomla 4.4 and thus make it available to third party developers both in 4.4 and 5.0.

### Testing Instructions

### Documentation Changes Required
