### PR TITLE
[3.x] Fixed comma not stripped in stringUrlUnicodeSlug

### DIFF
--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -185,7 +185,7 @@ class OutputFilter
         $str = str_replace('-', ' ', $str);
 
         // Replace forbidden characters by whitespaces
-        $str = preg_replace('#[:\#\*"@+=;!><&\.%()\]\/\'\\\\|\[]#', "\x20", $str);
+        $str = preg_replace('#[:\#\*"@+=;!><&\.%()\]\/\'\\\\|\[,]#', "\x20", $str);
 
         // Delete all '?'
         $str = str_replace('?', '', $str);

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -185,7 +185,7 @@ class OutputFilter
         $str = str_replace('-', ' ', $str);
 
         // Replace forbidden characters by whitespaces
-        $str = preg_replace('#[:\#\*"@+=;!><&\.%()\]\/\'\\\\|\[,]#', "\x20", $str);
+        $str = preg_replace('#[:\#\*"@+=,;!><&\.%()\]\/\'\\\\|\[]#', "\x20", $str);
 
         // Delete all '?'
         $str = str_replace('?', '', $str);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/47790

### Summary of Changes

The stringUrlUnicodeSlug method here uses a blocklist regex to strip out punctuation but the comma **`,`** character is missing from this blocklist. 
This PR adds the comma to the forbidden characters regex.


### Testing Instructions
described in https://github.com/joomla/joomla-cms/issues/47790

