### PR TITLE
[4.x] Add OutputFilter::escapeCsvFormula

### DIFF
--- a/Tests/OutputFilterTest.php
+++ b/Tests/OutputFilterTest.php
@@ -261,4 +261,36 @@ class OutputFilterTest extends TestCase
             'Should remove nested iFrame tags'
         );
     }
+
+    /**
+     * Data provider for testEscapeCsvFormula.
+     *
+     * @return  array
+     */
+    public function dataEscapeCsvFormula()
+    {
+        return [
+            'empty string'      => ['', ''],
+            'plain text'        => ['Banner name', 'Banner name'],
+            'equals sign'       => ['=1+1', ' =1+1'],
+            'plus sign'         => ['+1', ' +1'],
+            'minus sign'        => ['-1', ' -1'],
+            'at sign'           => ['@SUM(A1)', ' @SUM(A1)'],
+            'hyperlink formula' => ['=HYPERLINK("http://example.com","x")', ' =HYPERLINK("http://example.com","x")'],
+            'inner equals'      => ['a=1', 'a=1'],
+        ];
+    }
+
+    /**
+     * Tests escaping of CSV formula characters.
+     *
+     * @param   string  $value     The value to escape.
+     * @param   string  $expected  The expected result.
+     *
+     * @dataProvider  dataEscapeCsvFormula
+     */
+    public function testEscapeCsvFormula($value, $expected)
+    {
+        $this->assertEquals($expected, $this->object->escapeCsvFormula($value));
+    }
 }

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -287,4 +287,29 @@ class OutputFilter
 
         return $string;
     }
+
+    /**
+     * Escapes potential characters that start a formula in a CSV value to prevent injection attacks.
+     *
+     * A value beginning with `=`, `+`, `-` or `@` is evaluated as a formula by spreadsheet
+     * applications when the file is opened, so a leading space is prepended to keep it inert.
+     *
+     * @param   mixed  $value  The CSV field value.
+     *
+     * @return  mixed  The value, prefixed with a space when it starts with a formula character.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function escapeCsvFormula($value)
+    {
+        if ($value === '') {
+            return $value;
+        }
+
+        if (\in_array($value[0], ['=', '+', '-', '@'], true)) {
+            return ' ' . $value;
+        }
+
+        return $value;
+    }
 }

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -300,7 +300,7 @@ class OutputFilter
      *
      * @since   __DEPLOY_VERSION__
      */
-    public static function escapeCsvFormula($value)
+    public static function escapeCsvFormula(string $value): string
     {
         if ($value === '') {
             return $value;

--- a/src/OutputFilter.php
+++ b/src/OutputFilter.php
@@ -294,9 +294,9 @@ class OutputFilter
      * A value beginning with `=`, `+`, `-` or `@` is evaluated as a formula by spreadsheet
      * applications when the file is opened, so a leading space is prepended to keep it inert.
      *
-     * @param   mixed  $value  The CSV field value.
+     * @param   string  $value  The CSV field value.
      *
-     * @return  mixed  The value, prefixed with a space when it starts with a formula character.
+     * @return  string  The value, prefixed with a space when it starts with a formula character.
      *
      * @since   __DEPLOY_VERSION__
      */


### PR DESCRIPTION
Adds a shared `escapeCsvFormula()` method to `OutputFilter`.

A value beginning with `=`, `+`, `-` or `@` that is written into a CSV file is evaluated as a formula when the file is opened directly in a spreadsheet application (CSV formula injection, CWE-1236). Prepending a space keeps the value inert while leaving it readable.

The CMS currently implements this twice, in `ActionlogsHelper` and (pending in joomla/joomla-cms#48047) in the banner tracks export. Per the discussion on that PR the shared implementation belongs in the framework filter package rather than the CMS `OutputFilter`, so that the CMS can move both call sites onto it in 6.2 and third party extensions can use it too.

Unit tests covering the formula characters, an inner `=`, plain text and the empty string are included in `Tests/OutputFilterTest.php`.

Related: joomla/joomla-cms#48047